### PR TITLE
fix: remove endpoint version from base api Urls

### DIFF
--- a/src/abax-client.ts
+++ b/src/abax-client.ts
@@ -56,8 +56,8 @@ export interface AbaxClientConfig {
 }
 
 const apiUrls = {
-  sandbox: 'https://api-test.abax.cloud/v1',
-  production: 'https://api.abax.cloud/v1',
+  sandbox: 'https://api-test.abax.cloud',
+  production: 'https://api.abax.cloud',
 };
 
 export class AbaxClient {


### PR DESCRIPTION
`https://api.abax.cloud/v1/v2/equipment/` gives 404, obviously.

The versioning here is per-endpoint, not for the whole API, so we shouldn't include `v1` in the base URL.