### PR TITLE
feat: add utility function for decoding abax profile id token

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "date-fns": "^2.30.0",
     "exponential-backoff": "^3.1.1",
+    "fast-jwt": "^3.1.1",
     "ts-invariant": "^0.10.3",
     "typical-fetch": "^2.0.0",
     "zod": "^3.21.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   exponential-backoff:
     specifier: ^3.1.1
     version: 3.1.1
+  fast-jwt:
+    specifier: ^3.1.1
+    version: 3.1.1
   ts-invariant:
     specifier: ^0.10.3
     version: 0.10.3
@@ -981,6 +984,15 @@ packages:
       is-shared-array-buffer: 1.0.2
     dev: true
 
+  /asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+    dependencies:
+      bn.js: 4.12.0
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+    dev: false
+
   /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
@@ -993,6 +1005,10 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
+
+  /bn.js@4.12.0:
+    resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
+    dev: false
 
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -1194,6 +1210,12 @@ packages:
     dependencies:
       esutils: 2.0.3
     dev: true
+
+  /ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
 
   /error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -1583,6 +1605,15 @@ packages:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
     dev: true
 
+  /fast-jwt@3.1.1:
+    resolution: {integrity: sha512-c6gqmiMU9kUIMs0XcsnnpBMA4A+zi/XULA47r6hYoLR7s1teJ+LwviwZdttCeTZ+F5ZuHlRigNe98C4qN6h4pw==}
+    engines: {node: '>=14 <22'}
+    dependencies:
+      asn1.js: 5.4.1
+      ecdsa-sig-formatter: 1.0.11
+      mnemonist: 0.39.5
+    dev: false
+
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
@@ -1839,7 +1870,6 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
 
   /internal-slot@1.0.5:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
@@ -2106,6 +2136,10 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+    dev: false
+
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -2124,6 +2158,12 @@ packages:
       pkg-types: 1.0.3
       ufo: 1.2.0
     dev: true
+
+  /mnemonist@0.39.5:
+    resolution: {integrity: sha512-FPUtkhtJ0efmEFGpU14x7jGbTB+s18LrzRL2KgoWz9YvcY3cPomz8tih01GbHwnGk/OmkOKfqd/RAQoc8Lm7DQ==}
+    dependencies:
+      obliterator: 2.0.4
+    dev: false
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -2201,6 +2241,10 @@ packages:
       define-properties: 1.2.0
       es-abstract: 1.22.1
     dev: true
+
+  /obliterator@2.0.4:
+    resolution: {integrity: sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==}
+    dev: false
 
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2480,6 +2524,10 @@ packages:
       isarray: 2.0.5
     dev: true
 
+  /safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
+
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
@@ -2487,6 +2535,10 @@ packages:
       get-intrinsic: 1.2.1
       is-regex: 1.1.4
     dev: true
+
+  /safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: false
 
   /semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}

--- a/src/authentication/__tests__/decode-abax-profile.test.ts
+++ b/src/authentication/__tests__/decode-abax-profile.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { decodeAbaxProfileToken } from '../decode-abax-profile';
+
+describe('decode-abax.profile.ts', () => {
+  it('should be able to decode a JWT id token correctly', () => {
+    const token =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lkZW50aXR5LmFiYXguY2xvdWQiLCJuYmYiOjEyMywiaWF0IjoxMjMsImV4cCI6MTIzLCJhdWQiOiJoZWxsbyIsImFtciI6WyJoZWxsbyJdLCJhdF9oYXNoIjoiMTIzYWJjIiwic2lkIjoiMTIzRUYiLCJzdWIiOiIxMjMiLCJhdXRoX3RpbWUiOjEyMywiaWRwIjoibG9jYWwiLCJodHRwOi8vc2NoZW1hcy5hYmF4Lm5vL2lkZW50aXR5L2NsYWltcy91c2VybmFtZSI6ImhlbGxvQGV4YW1wbGUuY29tIiwicm9sZSI6IkFkbWluaXN0cmF0b3IiLCJuYW1lIjoiTmFtZSBOYW1leSIsImxvY2FsZSI6Im5vIiwiaHR0cDovL3NjaGVtYXMuYWJheC5uby9pZGVudGl0eS9jbGFpbXMvb3JnYW5pemF0aW9uaWQiOiIxMjMiLCJodHRwOi8vc2NoZW1hcy5hYmF4Lm5vL2lkZW50aXR5L2NsYWltcy9jb3VudHJ5Y29kZSI6Ik5PIiwiZW1haWwiOiJoZWxsb0BleGFtcGxlLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJwaG9uZV9udW1iZXIiOiIrNDc5OTk5OTk5OSIsImh0dHA6Ly9zY2hlbWFzLmFiYXgubm8vaWRlbnRpdHkvY2xhaW1zL3NlY3VyaXR5c3RhbXAiOiIxMjNhYmMifQ.9NTEjVBPoFye2ZLu4OSSGc4j8fIpRFyEoJEFLw9-C2U';
+
+    const decoded = decodeAbaxProfileToken(token);
+
+    expect(decoded).toMatchObject({
+      iss: 'https://identity.abax.cloud',
+      nbf: 123,
+      iat: 123,
+      exp: 123,
+      aud: 'hello',
+      amr: ['hello'],
+      at_hash: '123abc',
+      sid: '123EF',
+      sub: '123',
+      auth_time: 123,
+      idp: 'local',
+      'http://schemas.abax.no/identity/claims/username': 'hello@example.com',
+      role: 'Administrator',
+      name: 'Name Namey',
+      locale: 'no',
+      'http://schemas.abax.no/identity/claims/organizationid': '123',
+      'http://schemas.abax.no/identity/claims/countrycode': 'NO',
+      email: 'hello@example.com',
+      email_verified: true,
+      phone_number: '+4799999999',
+      'http://schemas.abax.no/identity/claims/securitystamp': '123abc',
+    });
+  });
+  it('should fail to decode a bad token', () => {
+    const token = 'asdf';
+    expect(() => decodeAbaxProfileToken(token)).toThrow();
+  });
+});

--- a/src/authentication/decode-abax-profile.ts
+++ b/src/authentication/decode-abax-profile.ts
@@ -1,0 +1,35 @@
+import { createDecoder } from 'fast-jwt';
+import { z } from 'zod';
+
+export const abaxIdTokenPayload = z.object({
+  iss: z.string(),
+  nbf: z.number(),
+  iat: z.number(),
+  exp: z.number(),
+  aud: z.string(),
+  amr: z.array(z.string()),
+  at_hash: z.string(),
+  sid: z.string(),
+  sub: z.string(),
+  auth_time: z.number(),
+  idp: z.string(),
+  'http://schemas.abax.no/identity/claims/username': z.string(),
+  role: z.string(),
+  name: z.string(),
+  locale: z.string(),
+  'http://schemas.abax.no/identity/claims/organizationid': z.string(),
+  'http://schemas.abax.no/identity/claims/countrycode': z.string(),
+  email: z.string(),
+  email_verified: z.boolean(),
+  phone_number: z.string(),
+  'http://schemas.abax.no/identity/claims/securitystamp': z.string(),
+});
+
+export type AbaxIdTokenPayload = z.infer<typeof abaxIdTokenPayload>;
+
+/** Extract Abax Profile data from a JWT id token that was retrieved with the `abax_profile` scope. */
+export function decodeAbaxProfileToken(idToken: string): AbaxIdTokenPayload {
+  const decode = createDecoder();
+
+  return abaxIdTokenPayload.parse(decode(idToken));
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,3 +10,4 @@ export * from './calls/list-equipment.js';
 export * from './authentication/abax-auth.js';
 export * from './authentication/types.js';
 export type { AuthorizationCodeInput } from './authentication/calls.js';
+export * from './authentication/decode-abax-profile.js';


### PR DESCRIPTION
> User-related scopes (Authorization Code Flow only)
> - openid - request the JWT id_token
> - abax_profile - request the id_token to include information about the user (name, email and organization id among others)
> - offline_access - request the refresh token

https://developers.abax.cloud/getting-started#authorizing-access-to-api

This is quite handy, but not every use case calls for decoding this token.

Should we consider decoding the idToken (if it is defined) and returning the payload in the `getCredentialsFromCode` method?

We should possibly have a separate method for decoding an id token when the `abax_profile` scope is not requested.