### PR TITLE
fix: import correctly with js path ending

### DIFF
--- a/src/abax-client.spec.ts
+++ b/src/abax-client.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { AbaxClient } from './main';
+import { AbaxClient } from './main.js';
 
 describe('abax-client', () => {
   const initialiseClient = async () => {

--- a/src/authentication/abax-auth.ts
+++ b/src/authentication/abax-auth.ts
@@ -1,9 +1,9 @@
-import { getTokenCall, refreshCall } from './calls';
+import { getTokenCall, refreshCall } from './calls.js';
 import {
   type AbaxCredentials,
   AbaxGetTokenError,
   AbaxRefreshTokenError,
-} from './types';
+} from './types.js';
 
 export type AbaxScope =
   | 'openid' // request the JWT id_token

--- a/src/calls/list-equipment.ts
+++ b/src/calls/list-equipment.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { equipmentSchema } from './get-equipment';
+import { equipmentSchema } from './get-equipment.js';
 
 export interface ListEquipmentInput {
   /** Defaults to 1 */


### PR DESCRIPTION
Something in our toolchain missed this, which needs to be fixed. Here is a hotfix for now