### PR TITLE
fix: add correct grant type to authentication call

### DIFF
--- a/src/authentication/abax-auth.ts
+++ b/src/authentication/abax-auth.ts
@@ -107,7 +107,6 @@ export class AbaxAuth {
     const result = await getTokenCall({
       baseUrl: this.baseUrl,
       input: {
-        grantType: 'authorization_code',
         clientId: this.config.clientId,
         clientSecret: this.config.clientSecret,
         redirectUri: this.config.redirectUri,
@@ -134,7 +133,6 @@ export class AbaxAuth {
     const result = await getTokenCall({
       baseUrl: this.baseUrl,
       input: {
-        grantType: 'client_credentials',
         clientId: this.config.clientId,
         clientSecret: this.config.clientSecret,
       },

--- a/src/authentication/calls.ts
+++ b/src/authentication/calls.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 import { withZod } from '../common/utils.js';
 
 export interface GetTokenInput {
-  grantType: 'authorization_code' | 'client_credentials';
   code?: string;
   clientId: string;
   clientSecret: string;
@@ -37,7 +36,8 @@ export const getTokenCall = buildCall()
   .body(({ input }) => {
     const body = new URLSearchParams();
 
-    body.append('grant_type', input.grantType);
+    const grantType = input.code ? 'authorization_code' : 'client_credentials';
+    body.append('grant_type', grantType);
     body.append('client_id', input.clientId);
     body.append('client_secret', input.clientSecret);
     if (input.code) {


### PR DESCRIPTION
It turns out that we were always setting the grant type to `authorization_code` in  `getTokenCall`, even though that call meant to be used for both `authorization_code` and `client_credentials` auth flows. 