### PR TITLE
feat: list trip expenses sequentially to better handle rate limiting

### DIFF
--- a/src/abax-client.ts
+++ b/src/abax-client.ts
@@ -133,13 +133,19 @@ export class AbaxClient {
       [[]],
     );
 
-    const expenses = await Promise.all(
-      tripIdBatches.map(batch =>
-        this.list150TripExpenses({ query: { trip_ids: batch } }),
-      ),
-    );
+    const expenses: listTripExpensesResponse['items'][] = [];
 
-    return { items: expenses.flatMap(expense => expense.items) };
+    for (const batch of tripIdBatches) {
+      const response = await this.list150TripExpenses({
+        query: { trip_ids: batch },
+      });
+
+      expenses.push(response.items);
+    }
+
+    const items = expenses.flat(1);
+
+    return { items };
   }
 
   async getOdometerValuesOfTrips(


### PR DESCRIPTION
The `Promise.all` "Shotgun" approach is not very practical when you just end up with a bunch of 429 responses and have to `backOff` a lot. 

In some situations running sequential queries might be a bit slower, but it's a lot more reliable 