### PR TITLE
feat: depaginated trips query

### DIFF
--- a/src/calls/list-trips.ts
+++ b/src/calls/list-trips.ts
@@ -6,7 +6,7 @@ export type ListTripsInput = QueryEnvelope<{
   /** Defaults to 1 */
   page?: number;
 
-  /** Defaults to 1500 */
+  /** Defaults to 1500, if set to 0, all trips will be returned unpaginated */
   page_size?: number;
 
   /** The period cannot be longer than 3 months */


### PR DESCRIPTION
This makes it so that when page_size is set to 0, all trips will be fetched, 1500 at a time, and then returned to the user